### PR TITLE
m2k: Pattern Generator add instrument triggering

### DIFF
--- a/library/axi_logic_analyzer/axi_logic_analyzer.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer.v
@@ -112,6 +112,20 @@ module axi_logic_analyzer #(
 
   reg               streaming_on;
 
+  reg    [ 1:0]     trigger_i_m1 = 2'd0;
+  reg    [ 1:0]     trigger_i_m2 = 2'd0;
+  reg    [ 1:0]     trigger_i_m3 = 2'd0;
+  reg               trigger_adc_m1 = 1'd0;
+  reg               trigger_adc_m2 = 1'd0;
+  reg               trigger_la_m2 = 1'd0;
+  reg               pg_trigered = 1'd0;
+
+  reg    [ 1:0]     any_edge_trigger = 1'd0;
+  reg    [ 1:0]     rise_edge_trigger = 1'd0;
+  reg    [ 1:0]     fall_edge_trigger = 1'd0;
+  reg    [ 1:0]     high_level_trigger = 1'd0;
+  reg    [ 1:0]     low_level_trigger = 1'd0;
+
   reg     [15:0]    adc_data_mn = 'd0;
   reg     [31:0]    trigger_holdoff_counter = 32'd0;
 
@@ -149,6 +163,18 @@ module axi_logic_analyzer #(
   wire              trigger_out_s;
   wire    [31:0]    trigger_delay;
   wire              trigger_out_delayed;
+
+  wire    [19:0]    pg_trigger_config;
+
+  wire    [ 1:0]    pg_en_trigger_pins;
+  wire              pg_en_trigger_adc;
+  wire              pg_en_trigger_la;
+
+  wire    [ 1:0]    pg_low_level;
+  wire    [ 1:0]    pg_high_level;
+  wire    [ 1:0]    pg_any_edge;
+  wire    [ 1:0]    pg_rise_edge;
+  wire    [ 1:0]    pg_fall_edge;
 
   wire    [31:0]    trigger_holdoff;
   wire              trigger_out_holdoff;
@@ -280,6 +306,47 @@ module axi_logic_analyzer #(
     end
   end
 
+  // pattern generator instrument triggering
+
+  assign pg_any_edge   = pg_trigger_config[1:0];
+  assign pg_rise_edge  = pg_trigger_config[3:2];
+  assign pg_fall_edge  = pg_trigger_config[5:4];
+  assign pg_low_level  = pg_trigger_config[7:6];
+  assign pg_high_level = pg_trigger_config[9:8];
+
+  assign pg_en_trigger_pins = pg_trigger_config[17:16];
+  assign pg_en_trigger_adc  = pg_trigger_config[18];
+  assign pg_en_trigger_la   = pg_trigger_config[19];
+
+  assign trigger_active = |pg_trigger_config[19:16];
+  assign trigger = (ext_trigger & pg_en_trigger_pins) |
+                   (trigger_adc_m2 & pg_en_trigger_adc) |
+                   (trigger_out_s & pg_en_trigger_la);
+
+  assign ext_trigger = |(any_edge_trigger |
+                        rise_edge_trigger |
+                        fall_edge_trigger |
+                        high_level_trigger |
+                        low_level_trigger);
+
+  // sync
+  always @(posedge clk) begin
+    trigger_i_m1 <= trigger_i;
+    trigger_i_m2 <= trigger_i_m1;
+    trigger_i_m3 <= trigger_i_m2;
+
+    trigger_adc_m1 <= trigger_in;
+    trigger_adc_m2 <= trigger_adc_m1;
+  end
+
+  always @(posedge clk) begin
+    any_edge_trigger <= (trigger_i_m3 ^ trigger_i_m2) & pg_any_edge;
+    rise_edge_trigger <= (~trigger_i_m3 & trigger_i_m2) & pg_rise_edge;
+    fall_edge_trigger <= (trigger_i_m3 & ~trigger_i_m2) & pg_fall_edge;
+    high_level_trigger <= trigger_i_m3 & pg_high_level;
+    low_level_trigger <= ~trigger_i_m3 & pg_low_level;
+  end
+
   // upsampler pattern generator
 
   always @(posedge clk_out) begin
@@ -288,12 +355,16 @@ module axi_logic_analyzer #(
       dac_read <= 1'b0;
     end else begin
       dac_read <= 1'b0;
-        if (upsampler_counter_pg < divider_counter_pg) begin
-          upsampler_counter_pg <= upsampler_counter_pg + 1;
-        end else begin
-          upsampler_counter_pg <= 32'h0;
-          dac_read <= 1'b1;
-        end
+      pg_trigered <= trigger_active ? (trigger | pg_trigered) : 1'b0;
+      if (trigger_active & !pg_trigered) begin
+        upsampler_counter_pg <= 32'h0;
+        dac_read <= 1'b0;
+      end else if (upsampler_counter_pg < divider_counter_pg) begin
+        upsampler_counter_pg <= upsampler_counter_pg + 1;
+      end else begin
+        upsampler_counter_pg <= 32'h0;
+        dac_read <= 1'b1;
+      end
     end
   end
 
@@ -377,6 +448,7 @@ module axi_logic_analyzer #(
     .od_pp_n (od_pp_n),
 
     .triggered (up_triggered),
+    .pg_trigger_config (pg_trigger_config),
 
     .streaming(streaming),
 

--- a/library/axi_logic_analyzer/axi_logic_analyzer_reg.v
+++ b/library/axi_logic_analyzer/axi_logic_analyzer_reg.v
@@ -59,6 +59,7 @@ module axi_logic_analyzer_reg (
   output      [15:0]  od_pp_n,
 
   output      [31:0]  trigger_holdoff,
+  output      [19:0]  pg_trigger_config,
 
   input               triggered,
 
@@ -98,6 +99,7 @@ module axi_logic_analyzer_reg (
   reg     [15:0]  up_overwrite_data = 0;
   reg     [15:0]  up_od_pp_n = 0;
   reg     [31:0]  up_trigger_holdoff = 32'h0;
+  reg     [19:0]  up_pg_trigger_config = 20'h0;
   reg             up_triggered = 0;
   reg             up_streaming = 0;
 
@@ -125,6 +127,7 @@ module axi_logic_analyzer_reg (
       up_triggered <= 1'd0;
       up_streaming <= 1'd0;
       up_trigger_holdoff <= 32'h0;
+      up_pg_trigger_config <= 20'd0;
     end else begin
       up_wack <= up_wreq;
       if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h1)) begin
@@ -186,6 +189,9 @@ module axi_logic_analyzer_reg (
       if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h14)) begin
         up_trigger_holdoff <= up_wdata[31:0];
       end
+      if ((up_wreq == 1'b1) && (up_waddr[4:0] == 5'h15)) begin
+        up_pg_trigger_config <= up_wdata[19:0];
+      end
     end
   end
 
@@ -220,6 +226,7 @@ module axi_logic_analyzer_reg (
           5'h12: up_rdata <= {31'h0,up_triggered};
           5'h13: up_rdata <= {31'h0,up_streaming};
           5'h14: up_rdata <= up_trigger_holdoff;
+          5'h15: up_rdata <= {12'h0,up_pg_trigger_config};
           default: up_rdata <= 0;
         endcase
       end else begin
@@ -230,7 +237,7 @@ module axi_logic_analyzer_reg (
 
   ad_rst i_core_rst_reg (.rst_async(~up_rstn), .clk(clk), .rstn(), .rst(reset));
 
-   up_xfer_cntrl #(.DATA_WIDTH(323)) i_xfer_cntrl (
+   up_xfer_cntrl #(.DATA_WIDTH(343)) i_xfer_cntrl (
     .up_rstn (up_rstn),
     .up_clk (up_clk),
     .up_data_cntrl ({ up_streaming,             // 1
@@ -248,6 +255,7 @@ module axi_logic_analyzer_reg (
                       up_rise_edge_enable,      // 18
                       up_edge_detect_enable,    // 18
                       up_io_selection,          // 16
+                      up_pg_trigger_config,     // 20
                       up_divider_counter_pg,    // 32
                       up_divider_counter_la}),  // 32
 
@@ -269,6 +277,7 @@ module axi_logic_analyzer_reg (
                       rise_edge_enable,       // 18
                       edge_detect_enable,     // 18
                       io_selection,           // 16
+                      pg_trigger_config,      // 20
                       divider_counter_pg,     // 32
                       divider_counter_la}));  // 32
 


### PR DESCRIPTION
The Pattern generator is part of the axi_logic_analyzer core.
The trigger signal can be internal (Oscilloscope or Logic Analyzer) or
external(TI or TO pins).